### PR TITLE
fix: Patch Regex expression to accomodate for multi-digit version numbers

### DIFF
--- a/lib/should-latch.js
+++ b/lib/should-latch.js
@@ -1,7 +1,7 @@
 /* eslint-disable security/detect-unsafe-regex */
 const latchMajor = /^\d+\.0\.0$/;
 const latchMinor = /^\d+\.\d+\.0$/;
-const latchPatch = /^\d+\.\d\.\d+$/;
+const latchPatch = /^\d+\.\d+\.\d+$/;
 const latchPrerelease = /^\d+\.\d+\.\d+(-(.*\.)?\d+)?$/;
 
 /**

--- a/lib/should-latch.test.js
+++ b/lib/should-latch.test.js
@@ -3,7 +3,7 @@
 const semver = require("semver");
 const shouldLatch = require("./should-latch");
 
-const version = "1.0.0";
+const version = "1.10.10";
 
 describe("latch none", () => {
 	it.each`


### PR DESCRIPTION
Fixes https://github.com/ext/semantic-release-lerna/issues/87